### PR TITLE
Error quickly if the data directory does not exist

### DIFF
--- a/templates/couchdb2.j2
+++ b/templates/couchdb2.j2
@@ -49,9 +49,12 @@ start() {
     [ ! -d "$piddir" ] && mkdir -p "$piddir"
     chown -R "$user":"$group" "$piddir"
     chmod 755 "$piddir"
-    [ ! -d "$datadir" ] && mkdir -p "$datadir"
-    chown -R "$user":"$group" "$datadir"
-    chmod 755 "$datadir"
+
+    # if a data directory does not exist. error quickly
+    if [ ! -d "$datadir" ] ; then
+        emit "$name could not start because data directory does not exist"
+        return 1
+    fi
 
     # Setup any environmental stuff beforehand
 


### PR DESCRIPTION
Changes the service init to error quickly if the data directory does not exist.

Doing this because in our deployment we store the data in an encrypted partition. We rebooted the machine and before the encrypted drive could be mounted, couch  started and the mkdir command created an unencrypted directory.