### PR TITLE
create data dir on clean install

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,6 +21,7 @@
   with_items:
     - d: '{{couchdb_etc_pki_dir}}'
     - d: '{{couchdb_dir}}/etc/local.d'
+    - d: '{{couchdb_data_dir}}'
   file:
     path: '{{item.d}}'
     state: directory


### PR DESCRIPTION
As @emord pointed out [here](https://github.com/dimagi/commcarehq-ansible/pull/960#discussion_r141923488), looks like this was accidentally broken by https://github.com/andrewrothstein/ansible-couchdb-cluster/commit/826df6010e191f17c35be598e9e4ba79d538c47f