### PR TITLE
allow setting reduce_limit config for query server

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,6 +35,8 @@ couchdb_pki_cert_suffix: '.pem'
 couchdb_require_valid_user: false
 couchdb_require_valid_user_node_local: false
 
+couchdb_reduce_limit: true
+
 couchdb_init: systemd
 couchdb_activate: True
 couchdb_async_io_threads: 16

--- a/templates/query_server_config.ini.j2
+++ b/templates/query_server_config.ini.j2
@@ -1,0 +1,2 @@
+[query_server_config]
+reduce_limit = {{ couchdb_reduce_limit }}


### PR DESCRIPTION
http://docs.couchdb.org/en/stable/config/query-servers.html?highlight=reduce_limit#query_server_config/reduce_limit

Occasionally this is required when reducing objects