### PR TITLE
Use strings to specify configuration values

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,10 +32,10 @@ couchdb_pki_cert_suffix: '.pem'
 #  alice: alice-password
 
 # When this option is set to true, no requests are allowed from anonymous users. Everyone must be authenticated.
-couchdb_require_valid_user: false
-couchdb_require_valid_user_node_local: false
+couchdb_require_valid_user: 'false'
+couchdb_require_valid_user_node_local: 'false'
 
-couchdb_reduce_limit: true
+couchdb_reduce_limit: 'true'
 
 couchdb_init: systemd
 couchdb_activate: True


### PR DESCRIPTION
@andrewrothstein @snopoke This was introduced in https://github.com/andrewrothstein/ansible-couchdb-cluster/pull/5

Whenever a configuration is a YAML boolean it is written as True/False. When False has the capital F, I believe that it is interpreted as true.