### PR TITLE
Update template for Python 3

### DIFF
--- a/templates/admins.ini.j2
+++ b/templates/admins.ini.j2
@@ -6,7 +6,7 @@
 ; changing this.
 {% if couchdb_admins is defined %}
 [admins]
-{% for (userid, pwd) in couchdb_admins.iteritems() %}
+{% for (userid, pwd) in couchdb_admins.items() %}
 {{userid}} = {{pwd|couchdb_password_hash(userid|hash('sha1'))}}
 {% endfor %}
 {% else %}


### PR DESCRIPTION
Error seen while running on Python 3:
```
TASK [andrewrothstein.couchdb-cluster : configurate…] **************************************************************************************************************
ok: [...] => (item={‘f’: ‘httpd_proxies.ini’})
ok: [...] => (item={‘f’: ‘chttpd.ini’})
failed: [...] (item={‘f’: ‘admins.ini’}) => {“ansible_loop_var”: “item”, “changed”: false, “item”: {“f”: “admins.ini”}, “msg”: “AnsibleUndefinedVariable: ‘dict object’ has no attribute ‘iteritems’”}
...
```