### PR TITLE
Convert password and salt to text before printing

### DIFF
--- a/filter_plugins/couchdb_password_hash.py
+++ b/filter_plugins/couchdb_password_hash.py
@@ -14,17 +14,17 @@ except ImportError:
 
 
 def couchdb_password_hash(password, salt, iterations=10):
-    salt = salt.encode('utf-8') if isinstance(salt, six.text_type) else salt
+    bsalt = salt.encode('utf-8') if isinstance(salt, six.text_type) else salt
     if not HAS_PASSLIB:
         return '-hashed-{hash},{salt}'.format(
-            hash=hashlib.sha1(password + salt),
+            hash=hashlib.sha1(password + bsalt).hexdigest,
             salt=salt
         )
     else:
-        dk = pbkdf2_sha1.using(rounds=iterations, salt=salt).hash(password)
+        dk = pbkdf2_sha1.using(rounds=iterations, salt=bsalt).hash(password)
         decoded = binary.ab64_decode(dk.split('$')[-1])
         return '-pbkdf2-{hash},{salt},{iterations}'.format(
-            hash=binascii.hexlify(decoded),
+            hash=binascii.hexlify(decoded).decode("ascii"),
             salt=salt,
             iterations=iterations
         )

--- a/filter_plugins/couchdb_password_hash.py
+++ b/filter_plugins/couchdb_password_hash.py
@@ -17,7 +17,7 @@ def couchdb_password_hash(password, salt, iterations=10):
     bsalt = salt.encode('utf-8') if isinstance(salt, six.text_type) else salt
     if not HAS_PASSLIB:
         return '-hashed-{hash},{salt}'.format(
-            hash=hashlib.sha1(password + bsalt).hexdigest,
+            hash=hashlib.sha1(password + bsalt).hexdigest(),
             salt=salt
         )
     else:


### PR DESCRIPTION
Without this conversion password and salt are represented as byte strings, which are delimited with `b'...'` on Python 3.

Tested on Python 2 and 3.

Fixes bad update to admins.ini on Python 3 (sensitive output sanitized)
```diff
changed: [host] => (item={'f': 'admins.ini'})
--- before: /usr/local/couchdb2/couchdb/etc/local.d/admins.ini
+++ after: .../admins.ini.j2
@@ -5,4 +5,4 @@
 ; 'username = password' lines. Don't forget to restart CouchDB after
 ; changing this.
 [admins]
-username = -pbkdf2-password,salt,10
+username = -pbkdf2-b'password',b'salt',10
```